### PR TITLE
detect single (xAx) and dual (xBx) zone sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ i2c = I2C(scl=Pin(5), sda=Pin(4))
 sensor = mlx90614.MLX90614(i2c)
 print(sensor.read_ambient_temp())
 print(sensor.read_object_temp())
+if sensor.dual_zone:
+    print(sensor.object2_temp)
 ```
 
 Continuous measurement

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -16,6 +16,8 @@ Now, to make basic measurement::
     sensor = mlx90614.MLX90614(i2c)
     print(sensor.read_ambient_temp())
     print(sensor.read_object_temp())
+    if sensor.dual_zone:
+        print(sensor.object2_temp)
 
 To perform continuous measurement::
 
@@ -23,3 +25,7 @@ To perform continuous measurement::
     while True:
         print(sensor.read_ambient_temp(), sensor.read_object_temp())
         time.sleep_ms(500)
+
+There are some useful properties:
+    * ``.dual_zone`` - set to ``True`` if the sensor has two thermopiles
+    * ``.ambient_temp`` - equivalent to read_ambient_temp(), also works for object and object2

--- a/docs/mlx90614.rst
+++ b/docs/mlx90614.rst
@@ -24,7 +24,7 @@ MLX90614
 
         Get the object temperature from the first or only thermopile
 
-    .. method:: read_object_temp2()
+    .. method:: read_object2_temp()
 
         Get the object temperature the second thermopile, if it exists
 

--- a/docs/mlx90614.rst
+++ b/docs/mlx90614.rst
@@ -14,14 +14,32 @@ MLX90614
     specifies which sensor to connect to, if you have more than one and have
     changed their addresses with the ``Addr`` pin.
 
+    All temperatures are returned in Celsius.
+
     .. method:: read_ambient_temp()
 
-        Get the ambient temperature in Celcius
+        Get the ambient sensor temperature
 
     .. method:: read_object_temp()
 
-        Get the object temperature in Celcius
+        Get the object temperature from the first or only thermopile
 
     .. method:: read_object_temp2()
 
-        Get the object temperature in Celcius from the second measurement zone
+        Get the object temperature the second thermopile, if it exists
+
+    .. property:: dual_zone
+
+        set to ``True`` if this sensor has two thermopiles
+
+    .. property:: ambient_temp
+
+        Equivalent to ``read_ambient_temp()``
+
+    .. property:: object_temp
+
+        Equivalent to ``read_object_temp()``
+
+    .. property:: object2_temp
+
+        Equivalent to ``read_object2_temp()``

--- a/mlx90614.py
+++ b/mlx90614.py
@@ -6,7 +6,7 @@ import ustruct
 
 _REGISTER_TA = const(0x06)     # ambient
 _REGISTER_TOBJ1 = const(0x07)  # object
-_REGISTER_TOBJ2 = const(0x08)  # object
+_REGISTER_TOBJ2 = const(0x08)  # object2
 
 class MLX90614:
 	def __init__(self, i2c, address=0x5a):
@@ -34,8 +34,20 @@ class MLX90614:
 	def read_object_temp(self):
 		return self.read_temp(_REGISTER_TOBJ1)
 
-	def read_object_temp2(self):
+	def read_object2_temp(self):
 		if self.dual_zone:
 			return self.read_temp(_REGISTER_TOBJ2)
 		else:
 			raise RuntimeError("Device only has one thermopile")
+
+	@property
+	def ambient_temp(self):
+		return self.read_ambient_temp()
+
+	@property
+	def object_temp(self):
+		return self.read_object_temp()
+
+	@property
+	def object2_temp(self):
+		return self.read_object2_temp()

--- a/mlx90614.py
+++ b/mlx90614.py
@@ -12,6 +12,9 @@ class MLX90614:
 	def __init__(self, i2c, address=0x5a):
 		self.i2c = i2c
 		self.address = address
+		_config1 = i2c.readfrom_mem(address, 0x25, 2)
+		_dz = ustruct.unpack('<H', _config1)[0] & (1<<6)
+		self.dual_zone = True if _dz else False
 
 	def read16(self, register):
 		data = self.i2c.readfrom_mem(self.address, register, 2)
@@ -32,4 +35,7 @@ class MLX90614:
 		return self.read_temp(_REGISTER_TOBJ1)
 
 	def read_object_temp2(self):
-		return self.read_temp(_REGISTER_TOBJ2)
+		if self.dual_zone:
+			return self.read_temp(_REGISTER_TOBJ2)
+		else:
+			raise RuntimeError("Device only has one thermopile")


### PR DESCRIPTION
and act accordingly. If having dual zones is important to your use
case, check the `.dual_zone` attribute, otherwise you will get a
RuntimeError exception