### PR TITLE
define freq on I2c

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ ampy put mlx90614.py
 import mlx90614
 from machine import I2C, Pin
 
-i2c = I2C(scl=Pin(5), sda=Pin(4))
+i2c = I2C(scl=Pin(5), sda=Pin(4), freq=100000)
 sensor = mlx90614.MLX90614(i2c)
 
 print(sensor.read_ambient_temp())
@@ -36,7 +36,7 @@ import time
 import mlx90614
 from machine import I2C, Pin
 
-i2c = I2C(scl=Pin(5), sda=Pin(4))
+i2c = I2C(scl=Pin(5), sda=Pin(4), freq=100000)
 sensor = mlx90614.MLX90614(i2c)
 
 while True:


### PR DESCRIPTION
The MLX90614 sensor's maximum frequency is specified as 100 kHz on page 15 of the [MLX90614 manual](https://www.sparkfun.com/datasheets/Sensors/Temperature/MLX90614_rev001.pdf). 

> The MLX90614 meets all the timing specifications of the SMBus [1]. The maximum frequency of the MLX90614 SMBus is 100KHz and the minimum is 10KHz.

The default I2C frequency setting of 400 kHz was causing significant noise in the received data. Adjusting the frequency to match the sensor's specification it's necessary to minimize noise.
